### PR TITLE
Rewritten, can now continue reads between files

### DIFF
--- a/StackedReader.hpp
+++ b/StackedReader.hpp
@@ -1,133 +1,138 @@
 #pragma once
-
 #include "_reader.hpp"
+
 #include <fstream>
-#include <cstring>
-#include <new>
+#include <string>
 #include <cstdint>
+#include <sstream>
 #include <vector>
+#include <exception>
 
-class StackedReader : public _reader {
+template <typename CharT = char>
+class StackedReader : public reader_interface<CharT> {
 protected:
-	struct File {
-		std::ifstream ifs;
-		std::string name;
-		int Look, Look2;
-		std::uint64_t Line, Char;
-		File(std::string const& fname)
-		: ifs(fname), name(fname), Look(0), Look2(0), Line(1), Char(0) {
-			Look2 = ifs.get();
-		}
-		File(char const * const fname)
-		: ifs(fname), name(fname), Look(0), Look2(0), Line(1), Char(0) {
-			Look2 = ifs.get();
-		}
-	};
-	std::vector<File> files;
+    using rface = reader_interface<CharT>;
+    using NameString = typename rface::NameString;
+    using StringT = typename rface::StringT;
+    using EOFErr = typename rface::EOFErr;
+    static constexpr typename std::basic_ifstream<CharT>::int_type
+        EndOfField = std::basic_ifstream<CharT>::traits_type::eof();
+
+    class EmptyReaderStackErr : public std::exception {};
+
+    struct File {
+        std::basic_ifstream<CharT> ifs;
+        NameString name;
+        CharT Look;
+        typename std::basic_ifstream<CharT>::int_type Look2;
+        //designed for extremes in either dimension
+        std::uintmax_t Char, Line;
+    };
+    std::vector<File> fs;
 public:
-	StackedReader(std::string const& fname){ files.emplace_back(fname); }
-	StackedReader(char const * const fname){ files.emplace_back(fname); }
-    StackedReader(){}
-
-    ///@Returns true if file was opened and made the current file\
-				false if file is already opened or if file could not be opened.
-    bool Open(char const * fname)override{
-		for(auto const& f : files){
-			if(f.name == fname){
-				return false;
-			}
-		}
-		files.emplace_back(fname);
-		return files.back().ifs.is_open();
-    }
-    ///@Returns true if file was opened and made the current file\
-				false if file is already opened or if file could not be opened.
-    bool Open(std::string const& fname)override{
-		for(auto const& f : files){
-			if(f.name == fname){
-				return false;
-			}
-		}
-		files.emplace_back(fname);
-		return files.back().ifs.is_open();
+    ///Copies filename, opens it, and adds it to the stack.
+    ///peek() is undefined until read() is called.
+    ///@Returns true if file was opened successfully.
+    bool open(NameString const& fname) override{
+        fs.push_back(File());
+        auto& back = fs.back();
+        back.ifs.open(fname);
+        if(!back.ifs.is_open())
+            return false;
+        back.name = fname;
+        back.Look2 = back.ifs.get();
+        back.Line = 1;
+        back.Char = 0;
+        return true;
     }
 
-    ///@Returns true if the current has been opened successfully,\
-				false if no files are open or open failed.
-    bool IsOpen()const override{
-        return files.size() > 0 && files.back().ifs.is_open();
+    ///Copies filename and opens it, then reads one character.
+    ///@Returns false if Reader.open() fails or if file was empty.
+    ///The value of peek() is defined as the first CharT in the file if operation succeeds.
+    bool openRead(NameString const& fname) override{
+        if(this->open(fname) && fs.back().Look2 != EndOfField){
+            this->read();
+            return true;
+        }else return false;
     }
 
-    ///@Returns Number of files currently in the stack
-	std::size_t FileCount()const{
-		static_assert(sizeof(std::vector<File>::size_type)<=sizeof(std::size_t));
-		return files.size();
-	}
-
-	///@Returns true if current file has zero length,\
-				false if |FileCount() == 0| or file is not empty
-    bool IsEmpty()override{
-    	//checks if position is zero, which is impossible for a valid Reader
-    	//since Open&Constructors read a character
-		return files.back().ifs.tellg()<=0 /*&& ifs.peek() == std::ifstream::traits_type::eof()*/;
+    ///@Returns true if the file is open.
+    bool isOpen()const override{
+        return !fs.empty() && fs.back().ifs.is_open();
     }
 
-    ///Returns the name of the current file exactly as opened.
-    ///should only be called when |FileCount() > 0 && IsOpen()|
-    std::string const& GetName()const override{
-        return files.back().name;
+    ///@Returns true if no characters are left to read.
+    bool atEOF()const override{
+        return fs.size()==1 && fs[0].Look2 == EndOfField;
     }
 
-    ///@Returns the line position (1-indexed) of the current file.
-    std::uint64_t GetLine()const override{
-		return files.back().Line;
+    ///@Returns the filename as a string.
+    NameString const& getName()const override{
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        return fs.back().name;
     }
 
-	///@Returns the character position (1-indexed) of the current file, \
-				resets when line is changed.
-    std::uint64_t GetChar()const override{
-		return files.back().Char;
+    ///@Returns the current line position of the reader.
+    std::uintmax_t getLine()const override{
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        return fs.back().Line;
     }
 
-	///@Returns the last read character in the current,\
-				will be '\0' until Read is called for the first time \
-				on the current file, or if the value is out of char range.
-    char Peek()const override{
-        return files.back().Look < 0 ? '\0' : files.back().Look;
+    ///@Retruns the current CharT position of the current line.
+    std::uintmax_t getChar()const override{
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        return fs.back().Char;
     }
 
-    ///@Returns the next character to be read in the current file, \
-				or '\0' if the value is out of char range.
-    char PeekNext()const override{
-    	std::uint64_t tLook2;
-    	/*if(files.back().Look2==-1 && files.size()>1)
-			 tLook2 = files.at(files.size()-2).Look2;
-		else*/
-			tLook2 = files.back().Look2;
-        return tLook2 < 0 ? '\0' : tLook2;
+    ///@Returns the last read CharT value.
+    CharT peek()const override{
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        return fs.back().Look;
     }
-    ///@Returns true if |FileCount() == 1| and the last file has reached EOF.
-    bool AtEOF()const override{ return files.size() == 1 && files.back().Look==-1; }
-	///@Returns true if |FileCount() == 1| and the last file will reach EOF on the next call to Read.
-    bool AtEOFNext()const override{ return files.size() == 1 && files.back().Look2==-1; }
-    ///@Returns the next character in the current file and updates the PeekNext character.
-	///Also returns '\0' if the value is out of char range.
-	///@Note will discard current file if |FileCount > 1| and it hits EOF, and return another call to itself. \
-			 Should not be called with |FileCount()==0|.
-	///@Throws a protected EOFErr exception when called with AtEOF==true, since this indicates an over-reading bug.
-    char Read()override{
-        if(files.back().Look==-1 && files.back().Look2==-1)
+
+    ///@Returns the next CharT value to be read.
+    ///@Fails if at EOF (no chars to peek)
+    CharT peekNext()const override{
+        if(fs.size()==1 && fs[0].Look2==EndOfField)
             throw EOFErr();
-		//if the next character to be read is EOF (so file is now empty),
-		//discard current file unless it is the only file left.
-		else if(files.back().Look2==-1 && files.size()>1)
-			files.pop_back();
-        files.back().Look = files.back().Look2;
-        if(files.back().Look=='\n'){
-            ++files.back().Line;
-            files.back().Char = 0;
-        }else ++files.back().Char;
-        files.back().Look2 = files.back().ifs.get();
-        return files.back().Look < 0 ? '\0' : files.back().Look;
+        return fs.back().Look2;
+    }
+
+    ///@Returns the next CharT in the file
+    ///@Fails if at EOF (no chars to read)
+    CharT read() override{
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        if(fs.size()>1 && fs.back().Look2 == EndOfField)
+            fs.pop_back();
+        if(fs.size()==1 && fs.back().Look2 == EndOfField)
+            throw EOFErr();
+        auto& back = fs.back();
+        back.Look = back.Look2;
+        back.Look2 = back.ifs.get();
+        if(StringT(1,back.Look)==StringT(1,'\n')){
+            ++back.Line;
+            back.Char = 0;
+        }else ++back.Char;
+        return back.Look;
+    }
+
+    ///@Returns a string of the next characters until delim or at EOF.
+    ///String is empty if at EOF (no chars to read)
+    StringT readUntil(CharT delim) override{
+        std::basic_ostringstream<CharT> buf;
+        if(fs.empty())
+            throw EmptyReaderStackErr();
+        while(!this->atEOF()){
+            CharT c = this->read();
+            if(c==delim) break;
+            buf.put(c);
+        }
+        return buf.str();
     }
 };
+

--- a/_reader.hpp
+++ b/_reader.hpp
@@ -6,49 +6,48 @@
 #include <cstdint>
 #include <cstddef>
 
-class _reader {
+template <typename CharTI/*, typename NameCT*/>
+class reader_interface {
 protected:
-    ///meant to help diagnose over-reading of the stream, not to be checked for, use AtEOF or AtEOFNext for that.
+    //meant to help diagnose over-reading of the stream, not to be checked for, use AtEOF or AtEOFNext for that.
     class EOFErr : std::exception {};
+    typedef /*std::basic_string<NameCT>*/ std::string NameString;
+    typedef std::basic_string<CharTI> StringT;
 public:
-	///Opens the file with fname and initializes the reader object to a valid state.
-    ///@Returns true if file was opened successfully and reader was initialized.
-    virtual bool Open(char const * fname) = 0;
-    ///Opens the file with fname and initializes the reader object to a valid state.
-    ///@Returns true if file was opened successfully and reader was initialized.
-    virtual bool Open(std::string const& fname) = 0;
+    //Copies filename and opens it.
+    //peek() is undefined until read() is called.
+    //@Returns true if file was opened successfully.
+    virtual bool open(NameString const& fname) = 0;
 
-	///@Returns true if stream is open and can be read from.
-	virtual bool IsOpen()const = 0;
+    virtual bool openRead(NameString const& fname) = 0;
 
-	///@Returns true if a stream is empty, else returns false.
-	///Should not be called on an uninitialized object.
-	///May modify internal state and cannot be called as const.
-    virtual bool IsEmpty() = 0;
-	///Returns the name of the stream exactly as opened.
-    virtual std::string const& GetName()const = 0;
+	//@Returns true if stream is open and can be read from.
+	virtual bool isOpen()const = 0;
 
-    ///Gets the current line position (1-indexed) of the stream
-    virtual std::uint64_t GetLine()const = 0;
+	//Returns the name of the stream exactly as opened.
+    virtual NameString const& getName()const = 0;
 
-	///Gets the current character position (1-indexed) of the stream
-	///resets every time the line changes
-    virtual std::uint64_t GetChar()const = 0;
+    //Gets the current line position (1-indexed) of the stream
+    virtual std::uintmax_t getLine()const = 0;
 
-	///@Returns the last read char in the stream.
-	///Will be '\0' until Read is called for the first time.
-	///Also returns '\0' if the value is out of char range.
-    virtual char Peek()const = 0;
-	///@Returns the next character to be read in the stream.
-	///Also returns '\0' if the value is out of char range.
-    virtual char PeekNext()const = 0;
+	//Gets the current character position (1-indexed) of the stream
+	//resets every time the line changes
+    virtual std::uintmax_t getChar()const = 0;
 
-	///@Returns true if the stream has reached EOF.
-    virtual bool AtEOF()const = 0;
-	///@Returns true if the stream will reach EOF on the next call to Read.
-    virtual bool AtEOFNext()const = 0;
-	///@Returns the next character in the stream and updates the PeekNext character.
-	///Also returns '\0' if the value is out of char range.
-	///@Throws a private EOFErr exception when called with AtEOF==true, since this indicates an over-reading bug.
-    virtual char Read() = 0;
+	//@Returns the last read char in the stream.
+	//Value is undefined until Read is called for the first time
+    virtual CharTI peek()const = 0;
+	//@Returns the next character to be read in the stream.
+    //@Throws protected EOFErr exception on debug if no characters are left to peek.
+    virtual CharTI peekNext()const = 0;
+
+	//@Returns true if the stream has reached EOF.
+    virtual bool atEOF()const = 0;
+	//@Returns the next character in the stream and updates the PeekNext character.
+	//Also returns '\0' if the value is out of char range.
+	//@Throws a protected EOFErr exception on debug when at EOF.
+    virtual CharTI read() = 0;
+
+    virtual std::basic_string<CharTI> readUntil(CharTI delim) = 0;
 };
+


### PR DESCRIPTION
misc:
- changed function casing from PascalCase to camelCase
- _reader abstract class changed to reader_interface
- reader_interface and implementations now support multiple encodings via a CharT template argument that defaults to char. (Newline check seems to work but has not been extensively tested)
- Char and Line are now uintmax_t instead of uint64_t.
removed:
- AtEOFNext
- IsEmpty
-constructor based file opening
added:
-open
-openRead
- readUntil
general:
- Now EOF should never enter Look, making atEOF() pointless, so atEOF() was made functionally the same as atEOFNext(), which also makes more sense logically.
- Furthermore, this means the user will never see EOF as a result of a read or peek, since an EOFErr is thrown for read(), peekNext().
  - peek() can never contain EOF and readUntil(CharT) returns an empty string if no chars are left.
- after open() is called and succeeds, the value of peek() is undefined until read() is called for the first time.
  - fails if file could not be opened.
- after openRead() is called and succeeds, the value of peek() is the first character in the stream.
  -fails if file could not be opened.
  -fails if file is empty.
-emptiness of a file can be checked using atEOF() right after open(), and this can be called on a const reader instance, where previously isEmpty() could not.